### PR TITLE
Python version is not available in this buildpack

### DIFF
--- a/index.md
+++ b/index.md
@@ -31,7 +31,7 @@ environment.  See [Using the starter applications](/docs/cfapps/starter_app_usag
 You can specify the version of Python to be used by your app by setting python-versionnumber in the runtime.txt file in the root of your application. For example:
 
 ```
-python-3.5.0
+python-3.6.0
 ```
 {: codeblock}
 


### PR DESCRIPTION
Python 3.5.0 is no longer available in the current buildpack. It would be best to show the user the latest Python 3 that is available to them.

The Python buildpack is at least 4 releases behind upstream Cloud Foundry.
https://github.com/cloudfoundry/python-buildpack/releases